### PR TITLE
Jenkinsfile using containerized MPLABX

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
 			steps {
 				unstash 'build'
 				dir('build') {
-					archiveArtifacts 'aseba-target-thymio2'
+					archiveArtifacts 'aseba-target-thymio2*'
 				}
 			}
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,58 @@
+#!groovy
+
+pipeline {
+	agent none
+	stages {
+		stage('Prepare') {
+			agent {
+				label 'docker'
+			}
+			steps {
+				// Jenkins will automatically check out the source
+				sh 'git submodule update --init'
+				sh '''
+					rm -rf aseba
+					git clone https://github.com/aseba-community/aseba.git --depth=1 --single-branch
+				'''
+				// Fixme: Stashed source includes .git otherwise submodule update fails
+				stash includes: 'molole/**,cmake-microchip/**,aseba/**', name: 'externals'
+			}
+		}
+		stage('Compile') {
+			agent {
+				dockerfile true
+			}
+			steps {
+				unstash 'externals'
+				// no dir('build') due to JENKINS-33510
+				sh '''
+					mkdir -p build && cd build
+					cmake -DASEBA_DIR=$PWD/../aseba ..
+					make
+				'''
+				stash includes: 'build/**', name: 'build'
+			}
+		}
+		stage('Test') {
+			agent { dockerfile true }
+			steps {
+				unstash 'externals'
+				unstash 'build'
+				// no dir('build') due to JENKINS-33510
+				sh '''
+					mkdir -p build && cd build
+					LANG=C ctest
+				'''
+			}
+		}
+		stage('Archive') {
+			agent any
+			steps {
+				unstash 'build'
+				dir('build') {
+					archiveArtifacts 'aseba-target-thymio2'
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
When combined with the CMake scripts in #29 and the Dockerfile in #31, this Jenkinsfile will compile the Thymio II firmware using the MPLABX `xc16` compiler.

See the [last successful build](https://ci.inria.fr/inirobot/job/David%20Sherman/job/aseba-target-thymio2/view/change-requests/job/PR-1/lastSuccessfulBuild/), which produces the firmware file [aseba-target-thymio2](https://ci.inria.fr/inirobot/job/David%20Sherman/job/aseba-target-thymio2/view/change-requests/job/PR-1/lastSuccessfulBuild/artifact/aseba-target-thymio2).

It calls `ctest` in anticipation of future unit tests, although there are none defined so far.